### PR TITLE
Fix worker build definition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     build:
@@ -18,7 +16,9 @@ services:
       - "8000:8000"
 
   worker:
-    build: .
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
     command: celery -A imagAine worker -l info
     volumes:
       - .:/app


### PR DESCRIPTION
## Summary
- remove obsolete version key from Compose file
- specify worker image build path to Dockerfile

## Testing
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6863eba1d7b8832688362082f85af8bc