### PR TITLE
Sprint 1: Estabilização — fecha gaps entre frontend e backend

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -150,6 +150,7 @@ class GenerateImageView(APIView):
         ),
         parameters=[
             OpenApiParameter('search', str, description='Busca no texto do prompt'),
+            OpenApiParameter('tag', str, description='Filtra por nome de tag (case insensitive)'),
         ],
     ),
 )
@@ -163,6 +164,10 @@ class PublicImageListView(generics.ListAPIView):
         base_queryset = Image.objects.filter(is_public=True).select_related(
             "user"
         ).prefetch_related("tags")
+
+        tag = self.request.query_params.get("tag")
+        if tag:
+            base_queryset = base_queryset.filter(tags__name__iexact=tag)
         annotated_queryset = base_queryset.annotate(
             like_count=Count("likes", distinct=True),
             comment_count=Count("comments", distinct=True),
@@ -194,6 +199,9 @@ class PublicImageListView(generics.ListAPIView):
         tags=['Gallery'],
         summary='Minhas imagens',
         description='Lista paginada de todas as imagens do usuário autenticado.',
+        parameters=[
+            OpenApiParameter('tag', str, description='Filtra por nome de tag (case insensitive)'),
+        ],
     ),
 )
 class UserImageListView(generics.ListAPIView):
@@ -201,11 +209,16 @@ class UserImageListView(generics.ListAPIView):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
+        queryset = Image.objects.filter(user=self.request.user).select_related(
+            "user"
+        ).prefetch_related("tags")
+
+        tag = self.request.query_params.get("tag")
+        if tag:
+            queryset = queryset.filter(tags__name__iexact=tag)
+
         queryset = (
-            Image.objects.filter(user=self.request.user)
-            .select_related("user")
-            .prefetch_related("tags")
-            .annotate(
+            queryset.annotate(
                 like_count=Count("likes", distinct=True),
                 comment_count=Count("comments", distinct=True),
                 effective_score=Coalesce(F("relevance_score"), Value(0.0)),

--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -93,6 +93,23 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
         return attrs
 
 
+class ChangePasswordSerializer(serializers.Serializer):
+    """Serializer for changing password while logged in."""
+    current_password = serializers.CharField(required=True, write_only=True)
+    new_password = serializers.CharField(required=True, write_only=True, min_length=8)
+    new_password_confirm = serializers.CharField(required=True, write_only=True)
+
+    def validate(self, attrs):
+        if attrs['new_password'] != attrs['new_password_confirm']:
+            raise serializers.ValidationError({"new_password": "Password fields didn't match."})
+        return attrs
+
+
+class DeleteAccountSerializer(serializers.Serializer):
+    """Serializer for account deletion confirmation."""
+    password = serializers.CharField(required=True, write_only=True)
+
+
 class UserSerializer(serializers.ModelSerializer):
     """Serializer for user details."""
     avatar_url = serializers.SerializerMethodField()

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -23,4 +23,8 @@ urlpatterns = [
     path('profile/avatar/', views.AvatarUploadView.as_view(), name='user_avatar'),
     path('profile/cover/', views.CoverUploadView.as_view(), name='user_cover'),
     path('preferences/', views.PreferencesView.as_view(), name='user_preferences'),
+
+    # Account management
+    path('password/change/', views.ChangePasswordView.as_view(), name='change_password'),
+    path('account/', views.DeleteAccountView.as_view(), name='delete_account'),
 ]

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -19,6 +19,8 @@ from rest_framework import serializers as drf_serializers
 
 from .models import PasswordResetToken, User
 from .serializers import (
+    ChangePasswordSerializer,
+    DeleteAccountSerializer,
     PasswordResetConfirmSerializer,
     PasswordResetRequestSerializer,
     UserLoginSerializer,
@@ -357,3 +359,68 @@ class PreferencesView(APIView):
         request.user.preferences = prefs
         request.user.save(update_fields=["preferences"])
         return Response(prefs, status=status.HTTP_200_OK)
+
+
+class ChangePasswordView(APIView):
+    """Change password for authenticated user."""
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=['Auth'],
+        summary='Trocar senha',
+        description='Altera a senha do usuário autenticado. Requer a senha atual.',
+        request=ChangePasswordSerializer,
+        responses={200: _detail_response, 400: _detail_response},
+    )
+    def post(self, request):
+        serializer = ChangePasswordSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if not request.user.check_password(serializer.validated_data['current_password']):
+            return Response(
+                {"detail": "Senha atual incorreta."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request.user.set_password(serializer.validated_data['new_password'])
+        request.user.save()
+
+        return Response(
+            {"detail": "Senha alterada com sucesso."},
+            status=status.HTTP_200_OK,
+        )
+
+
+class DeleteAccountView(APIView):
+    """Delete user account permanently."""
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(
+        tags=['Auth'],
+        summary='Deletar conta',
+        description=(
+            'Deleta permanentemente a conta do usuário e todas as suas imagens. '
+            'Requer confirmação com a senha atual. Ação irreversível.'
+        ),
+        request=DeleteAccountSerializer,
+        responses={
+            200: _detail_response,
+            400: _detail_response,
+        },
+    )
+    def delete(self, request):
+        serializer = DeleteAccountSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        if not request.user.check_password(serializer.validated_data['password']):
+            return Response(
+                {"detail": "Senha incorreta."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request.user.delete()
+
+        return Response(
+            {"detail": "Conta deletada com sucesso."},
+            status=status.HTTP_200_OK,
+        )

--- a/frontend/openapi-schema.yaml
+++ b/frontend/openapi-schema.yaml
@@ -9,6 +9,29 @@ info:
   license:
     name: Proprietary
 paths:
+  /api/auth/account/:
+    delete:
+      operationId: auth_account_destroy
+      description: Deleta permanentemente a conta do usuário e todas as suas imagens.
+        Requer confirmação com a senha atual. Ação irreversível.
+      summary: Deletar conta
+      tags:
+      - Auth
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
   /api/auth/login/:
     post:
       operationId: auth_login_create
@@ -37,6 +60,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginResponse'
+          description: ''
+  /api/auth/password/change/:
+    post:
+      operationId: auth_password_change_create
+      description: Altera a senha do usuário autenticado. Requer a senha atual.
+      summary: Trocar senha
+      tags:
+      - Auth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ChangePasswordRequest'
+        required: true
+      security:
+      - jwtAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DetailResponse'
           description: ''
   /api/auth/password/reset/confirm/:
     post:
@@ -913,6 +970,26 @@ components:
         * `4:3` - 4:3
         * `9:16` - 9:16
         * `3:2` - 3:2
+    ChangePasswordRequest:
+      type: object
+      description: Serializer for changing password while logged in.
+      properties:
+        current_password:
+          type: string
+          writeOnly: true
+          minLength: 1
+        new_password:
+          type: string
+          writeOnly: true
+          minLength: 8
+        new_password_confirm:
+          type: string
+          writeOnly: true
+          minLength: 1
+      required:
+      - current_password
+      - new_password
+      - new_password_confirm
     CommentLikeResponse:
       type: object
       properties:

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+    "/api/auth/account/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Deletar conta
+         * @description Deleta permanentemente a conta do usuário e todas as suas imagens. Requer confirmação com a senha atual. Ação irreversível.
+         */
+        delete: operations["auth_account_destroy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/login/": {
         parameters: {
             query?: never;
@@ -18,6 +38,26 @@ export interface paths {
          * @description Autentica o usuário e retorna par de tokens JWT (access + refresh).
          */
         post: operations["auth_login_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/password/change/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trocar senha
+         * @description Altera a senha do usuário autenticado. Requer a senha atual.
+         */
+        post: operations["auth_password_change_create"];
         delete?: never;
         options?: never;
         head?: never;
@@ -529,6 +569,12 @@ export interface components {
          * @enum {string}
          */
         AspectRatioEnum: "1:1" | "16:9" | "4:3" | "9:16" | "3:2";
+        /** @description Serializer for changing password while logged in. */
+        ChangePasswordRequest: {
+            current_password: string;
+            new_password: string;
+            new_password_confirm: string;
+        };
         CommentLikeResponse: {
             comment_id: number;
             is_liked: boolean;
@@ -838,6 +884,33 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    auth_account_destroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailResponse"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailResponse"];
+                };
+            };
+        };
+    };
     auth_login_create: {
         parameters: {
             query?: never;
@@ -859,6 +932,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LoginResponse"];
+                };
+            };
+        };
+    };
+    auth_password_change_create: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+                "application/x-www-form-urlencoded": components["schemas"]["ChangePasswordRequest"];
+                "multipart/form-data": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailResponse"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DetailResponse"];
                 };
             };
         };

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -12,6 +12,9 @@ import { GuidedWizardPage } from '@/pages/images/GuidedWizardPage';
 import { SettingsPage } from '@/pages/settings/SettingsPage';
 import { NotFoundPage } from '@/pages/misc/NotFoundPage';
 import { ProfilePage } from '@/pages/profile/ProfilePage';
+import { VerifyEmailPage } from '@/pages/auth/VerifyEmailPage';
+import { ForgotPasswordPage } from '@/pages/auth/ForgotPasswordPage';
+import { ResetPasswordPage } from '@/pages/auth/ResetPasswordPage';
 
 export const router = createBrowserRouter([
   {
@@ -38,6 +41,9 @@ export const router = createBrowserRouter([
     children: [
       { path: '/login', element: <LoginPage /> },
       { path: '/register', element: <RegisterPage /> },
+      { path: '/forgot-password', element: <ForgotPasswordPage /> },
+      { path: '/reset-password/:token', element: <ResetPasswordPage /> },
+      { path: '/verify-email/:token', element: <VerifyEmailPage /> },
     ],
   },
   {

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '@/features/auth/store';
 import { useThemeStore } from '@/hooks/useTheme';
 
@@ -13,6 +13,8 @@ export const AppHeader = ({ onOpenSidebar, onToggleSidebarCollapse, isSidebarCol
   const user = useAuthStore((state) => state.user);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const { theme, toggle: toggleTheme } = useThemeStore();
+  const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState('');
 
   useEffect(() => {
     const handleShortcut = (event: KeyboardEvent) => {
@@ -62,6 +64,14 @@ export const AppHeader = ({ onOpenSidebar, onToggleSidebarCollapse, isSidebarCol
                 data-global-search
                 type="search"
                 placeholder="Pesquisar..."
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && searchValue.trim()) {
+                    navigate(`/explore?search=${encodeURIComponent(searchValue.trim())}`);
+                    searchInputRef.current?.blur();
+                  }
+                }}
                 className="block w-full rounded-lg border border-border bg-surface py-2 pl-9 pr-14 text-sm text-fg placeholder:text-fg-muted transition-all focus:border-accent/40 focus:bg-elevated focus:outline-none"
               />
               <div className="absolute inset-y-0 right-1.5 flex items-center gap-1">

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -68,4 +68,12 @@ export const authApi = {
     });
     return data;
   },
+  async changePassword(payload: { current_password: string; new_password: string; new_password_confirm: string }) {
+    const { data } = await apiClient.post<{ detail: string }>('/auth/password/change/', payload);
+    return data;
+  },
+  async deleteAccount(payload: { password: string }) {
+    const { data } = await apiClient.delete<{ detail: string }>('/auth/account/', { data: payload });
+    return data;
+  },
 };

--- a/frontend/src/features/images/api.ts
+++ b/frontend/src/features/images/api.ts
@@ -112,6 +112,26 @@ export const imagesApi = {
     );
     return data;
   },
+  async fetchRelatedImages(imageId: number, limit = 6) {
+    const { data } = await apiClient.get<{
+      count: number;
+      results: { image: ImageRecord; similarity_score: number }[];
+    }>(`/images/${imageId}/related/`, { params: { limit } });
+    return data;
+  },
+  async fetchStyleSuggestions(limit = 5) {
+    const { data } = await apiClient.get<{
+      count: number;
+      results: {
+        label: string;
+        example_prompt: string;
+        example_image_id: number;
+        frequency: number;
+        confidence: number;
+      }[];
+    }>('/users/me/style-suggestions/', { params: { limit } });
+    return data;
+  },
   async refinePrompt(description: string, style?: string) {
     const { data } = await apiClient.post<{
       refined_prompt: string;

--- a/frontend/src/features/images/components/ImageDetailsDialog.tsx
+++ b/frontend/src/features/images/components/ImageDetailsDialog.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { MouseEvent, FormEvent } from 'react';
-import { Download, Heart, X, Share2, MessageCircle, Send, CornerDownRight, ChevronDown } from 'lucide-react';
+import { Download, Heart, X, Share2, MessageCircle, Send, CornerDownRight, ChevronDown, Sparkles } from 'lucide-react';
+import { imagesApi } from '@/features/images/api';
 import type { ImageRecord } from '@/features/images/types';
 
 export type ImageCommentReply = {
@@ -324,9 +325,58 @@ export const ImageDetailsDialog = ({
               </form>
             </div>
           )}
+
+          {/* Related Images */}
+          <RelatedImagesSection imageId={image.id} />
         </div>
       </div>
     </div>,
     document.body,
   );
 };
+
+function RelatedImagesSection({ imageId }: { imageId: number }) {
+  const [related, setRelated] = useState<{ image: ImageRecord; similarity_score: number }[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    imagesApi.fetchRelatedImages(imageId, 6)
+      .then((data) => setRelated(data.results))
+      .catch(() => setRelated([]))
+      .finally(() => setLoading(false));
+  }, [imageId]);
+
+  if (loading) return null;
+  if (related.length === 0) return null;
+
+  return (
+    <div className="img-dialog__related" style={{ padding: '1rem 1.25rem', borderTop: '1px solid var(--color-border)' }}>
+      <h4 style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--color-text-sec)', marginBottom: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+        <Sparkles size={14} />
+        Imagens relacionadas
+      </h4>
+      <div style={{ display: 'flex', gap: '0.5rem', overflowX: 'auto' }} className="no-scrollbar">
+        {related.map(({ image: relImg }) => (
+          <img
+            key={relImg.id}
+            src={relImg.image_url || ''}
+            alt={relImg.prompt || ''}
+            style={{
+              width: '72px',
+              height: '72px',
+              borderRadius: 'var(--radius-md)',
+              objectFit: 'cover',
+              cursor: 'pointer',
+              flexShrink: 0,
+              border: '1px solid var(--color-border)',
+              transition: 'opacity 0.15s',
+            }}
+            onMouseEnter={(e) => { (e.target as HTMLImageElement).style.opacity = '0.8'; }}
+            onMouseLeave={(e) => { (e.target as HTMLImageElement).style.opacity = '1'; }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { AuthLayout } from '@/features/auth/components/AuthLayout';
+import { authApi } from '@/features/auth/api';
+import { Mail, ArrowLeft, CheckCircle } from 'lucide-react';
+
+type FormData = { email: string };
+
+export const ForgotPasswordPage = () => {
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>();
+
+  const onSubmit = async (data: FormData) => {
+    setLoading(true);
+    try {
+      await authApi.requestPasswordReset({ email: data.email });
+    } catch {
+      // Silently succeed — don't reveal if email exists
+    } finally {
+      setSubmitted(true);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout
+      title="Recuperar senha"
+      subtitle="Informe seu email para receber o link de redefinição."
+      footer={
+        <span>
+          <Link to="/login" className="inline-flex items-center gap-1">
+            <ArrowLeft className="h-4 w-4" />
+            Voltar para o login
+          </Link>
+        </span>
+      }
+    >
+      {submitted ? (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <CheckCircle className="h-12 w-12 text-success" />
+          <p className="text-fg">
+            Se uma conta com esse email existir, você receberá um link para
+            redefinir sua senha.
+          </p>
+          <Link
+            to="/login"
+            className="mt-2 rounded-full bg-accent px-6 py-2.5 text-sm font-medium text-fg-inv transition-colors hover:bg-accent-hover"
+          >
+            Voltar para o login
+          </Link>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <div>
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-fg-sec">
+              Email
+            </label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-muted" />
+              <input
+                id="email"
+                type="email"
+                placeholder="seu@email.com"
+                className="w-full rounded-[var(--radius-md)] border border-border bg-inset py-2.5 pl-10 pr-4 text-sm text-fg placeholder:text-fg-muted focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                {...register('email', {
+                  required: 'Email é obrigatório',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: 'Email inválido',
+                  },
+                })}
+              />
+            </div>
+            {errors.email && (
+              <p className="mt-1 text-xs text-danger">{errors.email.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="mt-2 w-full rounded-full bg-accent py-2.5 text-sm font-medium text-fg-inv transition-colors hover:bg-accent-hover disabled:opacity-50"
+          >
+            {loading ? 'Enviando...' : 'Enviar link de recuperação'}
+          </button>
+        </form>
+      )}
+    </AuthLayout>
+  );
+};

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { AuthLayout } from '@/features/auth/components/AuthLayout';
+import { authApi } from '@/features/auth/api';
+import { CheckCircle, XCircle, Eye, EyeOff, Lock } from 'lucide-react';
+
+type FormData = {
+  new_password: string;
+  new_password_confirm: string;
+};
+
+export const ResetPasswordPage = () => {
+  const { token } = useParams<{ token: string }>();
+  const [status, setStatus] = useState<'form' | 'success' | 'error'>('form');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormData>();
+
+  const onSubmit = async (data: FormData) => {
+    if (!token) {
+      setStatus('error');
+      setErrorMessage('Token de redefinição não encontrado.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await authApi.confirmPasswordReset({
+        token,
+        new_password: data.new_password,
+        new_password_confirm: data.new_password_confirm,
+      });
+      setStatus('success');
+    } catch (err: unknown) {
+      setStatus('error');
+      const error = err as { response?: { data?: { detail?: string } } };
+      setErrorMessage(
+        error.response?.data?.detail || 'Token inválido ou expirado.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout
+      title="Redefinir senha"
+      subtitle={status === 'form' ? 'Escolha uma nova senha para sua conta.' : undefined}
+      footer={
+        <span>
+          <Link to="/login">Voltar para o login</Link>
+        </span>
+      }
+    >
+      {status === 'success' && (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <CheckCircle className="h-12 w-12 text-success" />
+          <p className="text-fg">Senha redefinida com sucesso!</p>
+          <Link
+            to="/login"
+            className="mt-2 rounded-full bg-accent px-6 py-2.5 text-sm font-medium text-fg-inv transition-colors hover:bg-accent-hover"
+          >
+            Fazer login
+          </Link>
+        </div>
+      )}
+
+      {status === 'error' && (
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <XCircle className="h-12 w-12 text-danger" />
+          <p className="text-fg">{errorMessage}</p>
+          <Link
+            to="/forgot-password"
+            className="mt-2 text-sm text-accent-text hover:text-accent"
+          >
+            Solicitar novo link
+          </Link>
+        </div>
+      )}
+
+      {status === 'form' && (
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+          <div>
+            <label htmlFor="new_password" className="mb-1.5 block text-sm font-medium text-fg-sec">
+              Nova senha
+            </label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-muted" />
+              <input
+                id="new_password"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Mínimo 8 caracteres"
+                className="w-full rounded-[var(--radius-md)] border border-border bg-inset py-2.5 pl-10 pr-10 text-sm text-fg placeholder:text-fg-muted focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                {...register('new_password', {
+                  required: 'Senha é obrigatória',
+                  minLength: { value: 8, message: 'Mínimo 8 caracteres' },
+                })}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-fg-muted hover:text-fg-sec"
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            {errors.new_password && (
+              <p className="mt-1 text-xs text-danger">{errors.new_password.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="confirm" className="mb-1.5 block text-sm font-medium text-fg-sec">
+              Confirmar nova senha
+            </label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-fg-muted" />
+              <input
+                id="confirm"
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Repita a senha"
+                className="w-full rounded-[var(--radius-md)] border border-border bg-inset py-2.5 pl-10 pr-4 text-sm text-fg placeholder:text-fg-muted focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+                {...register('new_password_confirm', {
+                  required: 'Confirmação é obrigatória',
+                  validate: (val) =>
+                    val === watch('new_password') || 'As senhas não coincidem',
+                })}
+              />
+            </div>
+            {errors.new_password_confirm && (
+              <p className="mt-1 text-xs text-danger">{errors.new_password_confirm.message}</p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="mt-2 w-full rounded-full bg-accent py-2.5 text-sm font-medium text-fg-inv transition-colors hover:bg-accent-hover disabled:opacity-50"
+          >
+            {loading ? 'Redefinindo...' : 'Redefinir senha'}
+          </button>
+        </form>
+      )}
+    </AuthLayout>
+  );
+};

--- a/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { AuthLayout } from '@/features/auth/components/AuthLayout';
+import { authApi } from '@/features/auth/api';
+import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
+
+export const VerifyEmailPage = () => {
+  const { token } = useParams<{ token: string }>();
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setMessage('Token de verificação não encontrado.');
+      return;
+    }
+
+    authApi.verifyEmail(token)
+      .then((res) => {
+        setStatus('success');
+        setMessage(res.detail);
+      })
+      .catch((err) => {
+        setStatus('error');
+        setMessage(
+          err.response?.data?.detail || 'Token inválido ou expirado.'
+        );
+      });
+  }, [token]);
+
+  return (
+    <AuthLayout
+      title="Verificação de email"
+      footer={
+        <span>
+          <Link to="/login">Voltar para o login</Link>
+        </span>
+      }
+    >
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {status === 'loading' && (
+          <>
+            <Loader2 className="h-12 w-12 animate-spin text-accent" />
+            <p className="text-fg-sec">Verificando seu email...</p>
+          </>
+        )}
+
+        {status === 'success' && (
+          <>
+            <CheckCircle className="h-12 w-12 text-success" />
+            <p className="text-fg">{message}</p>
+            <Link
+              to="/login"
+              className="mt-2 rounded-full bg-accent px-6 py-2.5 text-sm font-medium text-fg-inv transition-colors hover:bg-accent-hover"
+            >
+              Fazer login
+            </Link>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <XCircle className="h-12 w-12 text-danger" />
+            <p className="text-fg">{message}</p>
+            <Link
+              to="/register"
+              className="mt-2 text-sm text-accent-text hover:text-accent"
+            >
+              Criar nova conta
+            </Link>
+          </>
+        )}
+      </div>
+    </AuthLayout>
+  );
+};

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -1,11 +1,44 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { Sparkles } from 'lucide-react';
 import { imagesApi } from '@/features/images/api';
 import { ImageGrid } from '@/features/images/components/ImageGrid';
 import { StatCard } from '@/components/ui/StatCard';
 import { DashboardSkeleton } from '@/components/ui/Skeleton';
 import { QUERY_KEYS } from '@/lib/constants';
 import type { ImageRecord } from '@/features/images/types';
+
+function StyleSuggestionsWidget() {
+  const navigate = useNavigate();
+  const { data, isLoading } = useQuery({
+    queryKey: ['style-suggestions'],
+    queryFn: () => imagesApi.fetchStyleSuggestions(5),
+    retry: false,
+  });
+
+  if (isLoading || !data || data.results.length === 0) return null;
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3 flex items-center gap-2">
+        <Sparkles className="h-4 w-4 text-accent" />
+        <h2 className="m-0 text-lg font-medium text-fg">Sugestões para você</h2>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
+        {data.results.map((suggestion) => (
+          <button
+            key={suggestion.label}
+            onClick={() => navigate('/generate', { state: { prompt: suggestion.example_prompt } })}
+            className="flex-shrink-0 rounded-xl border border-border bg-surface px-4 py-3 text-left transition-colors hover:border-accent hover:bg-accent-soft"
+          >
+            <span className="block text-sm font-medium text-fg">{suggestion.label}</span>
+            <span className="mt-0.5 block text-xs text-fg-muted line-clamp-1">{suggestion.example_prompt}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export const DashboardPage = () => {
   const { data: myImagesResponse, isLoading } = useQuery({
@@ -43,6 +76,8 @@ export const DashboardPage = () => {
         <StatCard label="Galeria pública" value={publicCount} helper="Visíveis no feed global" />
         <StatCard label="Total" value={myImages.length} helper="Inclui falhas e imagens privadas" />
       </div>
+
+      <StyleSuggestionsWidget />
 
       <div className="mt-8">
         <div className="mb-4 flex items-center justify-between">

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -1,8 +1,12 @@
 import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import { useAuthStore } from '@/features/auth/store';
 import { authApi } from '@/features/auth/api';
 import { QUERY_KEYS } from '@/lib/constants';
+import { Eye, EyeOff } from 'lucide-react';
 
 type AspectOption = '1:1' | '16:9' | '9:16' | '21:9';
 
@@ -20,9 +24,49 @@ const ASPECT_OPTIONS: { value: AspectOption; label: string; shape: 'square' | 'l
   { value: '21:9', label: '21:9 Cinema', shape: 'landscape' },
 ];
 
+type ChangePasswordForm = {
+  current_password: string;
+  new_password: string;
+  new_password_confirm: string;
+};
+
 export const SettingsPage = () => {
   const user = useAuthStore((state) => state.user);
   const logout = useAuthStore((state) => state.logout);
+  const navigate = useNavigate();
+
+  const [showChangePassword, setShowChangePassword] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletePassword, setDeletePassword] = useState('');
+  const [showPasswords, setShowPasswords] = useState(false);
+
+  const pwForm = useForm<ChangePasswordForm>();
+
+  const changePasswordMutation = useMutation({
+    mutationFn: (data: ChangePasswordForm) => authApi.changePassword(data),
+    onSuccess: () => {
+      toast.success('Senha alterada com sucesso.');
+      setShowChangePassword(false);
+      pwForm.reset();
+    },
+    onError: (err: unknown) => {
+      const error = err as { response?: { data?: { detail?: string } } };
+      toast.error(error.response?.data?.detail || 'Erro ao alterar senha.');
+    },
+  });
+
+  const deleteAccountMutation = useMutation({
+    mutationFn: (password: string) => authApi.deleteAccount({ password }),
+    onSuccess: () => {
+      toast.success('Conta deletada.');
+      logout();
+      navigate('/login');
+    },
+    onError: (err: unknown) => {
+      const error = err as { response?: { data?: { detail?: string } } };
+      toast.error(error.response?.data?.detail || 'Erro ao deletar conta.');
+    },
+  });
 
   const [selectedModel, setSelectedModel] = useState(MODEL_OPTIONS[0]);
   const [aspect, setAspect] = useState<AspectOption>('1:1');
@@ -117,11 +161,63 @@ export const SettingsPage = () => {
                 </div>
                 <button
                   type="button"
+                  onClick={() => setShowChangePassword(!showChangePassword)}
                   className="h-11 w-full rounded-full border border-border bg-body px-6 text-sm font-semibold transition-colors hover:border-accent md:w-auto"
                 >
-                  Alterar senha
+                  {showChangePassword ? 'Cancelar' : 'Alterar senha'}
                 </button>
               </div>
+
+              {showChangePassword && (
+                <form
+                  onSubmit={pwForm.handleSubmit((data) => changePasswordMutation.mutate(data))}
+                  className="mb-6 space-y-4 rounded-xl border border-border bg-body p-5"
+                >
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-fg-sec">Senha atual</label>
+                    <div className="relative">
+                      <input
+                        type={showPasswords ? 'text' : 'password'}
+                        className="form-input h-11 w-full rounded-lg border border-border bg-inset px-4 text-fg focus:border-accent focus:ring-0"
+                        {...pwForm.register('current_password', { required: 'Obrigatório' })}
+                      />
+                      <button type="button" onClick={() => setShowPasswords(!showPasswords)} className="absolute right-3 top-1/2 -translate-y-1/2 text-fg-muted">
+                        {showPasswords ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                    {pwForm.formState.errors.current_password && <p className="mt-1 text-xs text-danger">{pwForm.formState.errors.current_password.message}</p>}
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-fg-sec">Nova senha</label>
+                    <input
+                      type={showPasswords ? 'text' : 'password'}
+                      className="form-input h-11 w-full rounded-lg border border-border bg-inset px-4 text-fg focus:border-accent focus:ring-0"
+                      placeholder="Mínimo 8 caracteres"
+                      {...pwForm.register('new_password', { required: 'Obrigatório', minLength: { value: 8, message: 'Mínimo 8 caracteres' } })}
+                    />
+                    {pwForm.formState.errors.new_password && <p className="mt-1 text-xs text-danger">{pwForm.formState.errors.new_password.message}</p>}
+                  </div>
+                  <div>
+                    <label className="mb-1.5 block text-sm font-medium text-fg-sec">Confirmar nova senha</label>
+                    <input
+                      type={showPasswords ? 'text' : 'password'}
+                      className="form-input h-11 w-full rounded-lg border border-border bg-inset px-4 text-fg focus:border-accent focus:ring-0"
+                      {...pwForm.register('new_password_confirm', {
+                        required: 'Obrigatório',
+                        validate: (val) => val === pwForm.watch('new_password') || 'As senhas não coincidem',
+                      })}
+                    />
+                    {pwForm.formState.errors.new_password_confirm && <p className="mt-1 text-xs text-danger">{pwForm.formState.errors.new_password_confirm.message}</p>}
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={changePasswordMutation.isPending}
+                    className="w-full rounded-full bg-accent py-2.5 text-sm font-semibold text-fg-inv transition-colors hover:bg-accent-hover disabled:opacity-50"
+                  >
+                    {changePasswordMutation.isPending ? 'Alterando...' : 'Confirmar alteração'}
+                  </button>
+                </form>
+              )}
 
               <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                 <label className="block">
@@ -311,11 +407,34 @@ export const SettingsPage = () => {
                   </div>
                   <button
                     type="button"
+                    onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
                     className="whitespace-nowrap rounded-full border border-red-900/50 bg-red-900/30 px-4 py-2 text-sm font-bold text-red-300 transition-colors hover:bg-red-900/50 hover:text-red-200"
                   >
-                    Deletar minha conta
+                    {showDeleteConfirm ? 'Cancelar' : 'Deletar minha conta'}
                   </button>
                 </div>
+                {showDeleteConfirm && (
+                  <div className="mt-4 space-y-3 rounded-xl border border-red-900/40 bg-red-950/20 p-4">
+                    <p className="text-sm text-fg-sec">
+                      Digite sua senha para confirmar. <strong className="text-danger">Todos os seus dados e imagens serão permanentemente deletados.</strong>
+                    </p>
+                    <input
+                      type="password"
+                      placeholder="Sua senha"
+                      value={deletePassword}
+                      onChange={(e) => setDeletePassword(e.target.value)}
+                      className="form-input h-11 w-full rounded-lg border border-red-900/40 bg-body px-4 text-fg placeholder:text-fg-muted focus:border-danger focus:ring-0"
+                    />
+                    <button
+                      type="button"
+                      disabled={!deletePassword || deleteAccountMutation.isPending}
+                      onClick={() => deleteAccountMutation.mutate(deletePassword)}
+                      className="w-full rounded-full bg-danger py-2.5 text-sm font-bold text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                    >
+                      {deleteAccountMutation.isPending ? 'Deletando...' : 'Confirmar exclusão permanente'}
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary

- Fecha todos os gaps identificados entre frontend e backend (9 tasks)
- Novos endpoints: trocar senha, deletar conta, filtro por tag
- 3 novas páginas de auth: verificação de email, reset de senha, recuperação
- Conecta funcionalidades existentes no backend que o frontend não usava

## Tasks completadas

| Task | Entrega |
|------|---------|
| S1-T01 | `/verify-email/:token` — página com loading/success/error |
| S1-T02 | `/reset-password/:token` — formulário + validação |
| S1-T03 | `/forgot-password` — solicita reset (mensagem genérica por segurança) |
| S1-T04 | `POST /api/auth/password/change/` + formulário inline na Settings |
| S1-T05 | `DELETE /api/auth/account/` + dialog de confirmação com senha |
| S1-T06 | Seção "Imagens relacionadas" no ImageDetailsDialog |
| S1-T07 | Widget "Sugestões para você" no Dashboard |
| S1-T08 | `?tag=` filter em public images e my-images |
| S1-T09 | Busca global ⌘K → Enter → navega para /explore?search= |

## Detalhes técnicos

### Backend
- `ChangePasswordSerializer` + `ChangePasswordView` (valida senha atual)
- `DeleteAccountSerializer` + `DeleteAccountView` (CASCADE em imagens)
- Tag filter via `tags__name__iexact` em PublicImageListView e UserImageListView
- Todos anotados com `@extend_schema`, spec e tipos atualizados

### Frontend
- 3 páginas auth seguindo padrão AuthLayout (glow, dark container)
- SettingsPage: formulário de trocar senha inline + dialog de deletar conta
- ImageDetailsDialog: seção de related images com thumbnails horizontais
- DashboardPage: widget de style suggestions com chips navegáveis
- AppHeader: busca global conectada ao /explore?search=
- 2 novos métodos na authApi + 2 novos na imagesApi

## Test plan

- [x] Testes auth: 13/13 passaram
- [x] Spec OpenAPI: 0 warnings
- [x] Swagger UI: 200
- [x] Tag filter: 200
- [x] Novos endpoints presentes na spec
- [x] SDD hook validou todos os commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)